### PR TITLE
Removes additional inflection acronym (#28 continued)

### DIFF
--- a/lib/casino/inflections.rb
+++ b/lib/casino/inflections.rb
@@ -4,5 +4,4 @@
 ActiveSupport::Inflector.inflections do |inflect|
   inflect.acronym 'CAS'
   inflect.acronym 'CASino'
-  inflect.acronym 'API'
 end


### PR DESCRIPTION
I missed another inflection acronym definition for "API" when submitting #28
