### PR TITLE
Don't override Ruby's YAML Engine

### DIFF
--- a/config/initializers/yaml.rb
+++ b/config/initializers/yaml.rb
@@ -1,1 +1,0 @@
-YAML::ENGINE.yamler = 'syck'


### PR DESCRIPTION
I ran into some deserialization issues in my host application due to CASino secretly overriding Ruby's YAML Engine parser. Removing this statement solved the problem for me and did not seem to cause any issues in CASino's specs.

If this is required for other host applications, then it should be set in that particular application, not this Engine.
