### PR TITLE
Fix typo in Two-factor authentication description

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,7 +35,7 @@ en:
   two_factor_authenticators:
     title: "Two-factor authentication"
     setup: "Set up two-factor authentication"
-    description: "Tow-factor authentication requires you to enter an additional one-time password (OTP) each time you try to login to your account. An OTP can be created with an application such as the <a href='http://support.google.com/accounts/bin/answer.py?hl=en&answer=1066447'>Google Authenticator</a> with your mobile phone."
+    description: "Two-factor authentication requires you to enter an additional one-time password (OTP) each time you try to login to your account. An OTP can be created with an application such as the <a href='http://support.google.com/accounts/bin/answer.py?hl=en&answer=1066447'>Google Authenticator</a> with your mobile phone."
     instructions: "If you are using Google Authenticator, scan the QR code below with the application. Enter the verification code in the text field below."
     disabled: "Currently disabled"
     enable: "Enable"


### PR DESCRIPTION
Just a typo fix. It hit me in the eyes when trying out CASino for the first time.
