### PR TITLE
Don't respond with 500 when an unsupported format is requested

### DIFF
--- a/app/controllers/casino/application_controller.rb
+++ b/app/controllers/casino/application_controller.rb
@@ -7,6 +7,10 @@ class CASino::ApplicationController < ::ApplicationController
   layout 'application'
   before_filter :set_locale
 
+  unless Rails.env.development?
+    rescue_from ActionView::MissingTemplate, with: :missing_template
+  end
+
   def cookies
     super
   end
@@ -30,5 +34,9 @@ class CASino::ApplicationController < ::ApplicationController
 
   def http_accept_language
     HttpAcceptLanguage::Parser.new request.env['HTTP_ACCEPT_LANGUAGE']
+  end
+
+  def missing_template(exception)
+    render plain: 'Format not supported', status: :not_acceptable
   end
 end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -6,6 +6,13 @@ describe CASino::SessionsController do
       CASino::LoginCredentialRequestorProcessor.any_instance.should_receive(:process)
       get :new, use_route: :casino
     end
+
+    context 'with an unsupported format' do
+      it 'sets the status code to 406' do
+        get :new, use_route: :casino, format: :xml
+        response.status.should == 406
+      end
+    end
   end
 
   describe 'POST "create"' do


### PR DESCRIPTION
When Rails receives a request for an unsupported format, a `ActionView::MissingTemplate` is thrown. This is why we catch the exception and set the status to 406 Not Acceptable instead of the default 500 Internal Server Error.

I was unable to find a better solution for this… :unamused:
