### PR TITLE
Force UTF-8 encoding on service parameter

### DIFF
--- a/app/processors/casino/processor_concern/service_tickets.rb
+++ b/app/processors/casino/processor_concern/service_tickets.rb
@@ -27,6 +27,7 @@ module CASino
       end
 
       def clean_service_url(dirty_service)
+        dirty_service = dirty_service.force_encoding('UTF-8')
         return dirty_service if dirty_service.blank?
         service_uri = Addressable::URI.parse dirty_service
         unless service_uri.query_values.nil?


### PR DESCRIPTION
We're using CAS in gateway mode and are experiencing errors when the original URL of the client application includes invalid UTF-8 characters. These are not "legitimate" user requests, but they happen a lot so it would be nice to prevent the error reports. 

Here's part of a backtrace:

activesupport-3.2.19/lib/active_support/core_ext/object/blank.rb:105→ =~
activesupport-3.2.19/lib/active_support/core_ext/object/blank.rb:105→ !~
activesupport-3.2.19/lib/active_support/core_ext/object/blank.rb:105→ blank?
casino-2.0.4/app/processors/casino/processor_concern/service_tickets.rb:30→ clean_service_url
casino-2.0.4/app/processors/casino/login_credential_requestor_processor.rb:54→ check_service_allowed
casino-2.0.4/app/processors/casino/login_credential_requestor_processor.rb:22→ process
casino-2.0.4/app/controllers/casino/sessions_controller.rb:10→ new
