### PR TITLE
Fixed NameError

### DIFF
--- a/app/processors/casino/processor_concern/two_factor_authenticators.rb
+++ b/app/processors/casino/processor_concern/two_factor_authenticators.rb
@@ -1,4 +1,5 @@
 require 'addressable/uri'
+require 'rotp'
 
 module CASino
   module ProcessorConcern


### PR DESCRIPTION
The ROTP was being referenced without properly load. The require is
enough to fix the issue.

Backtrace:

> NameError - uninitialized constant ROTP:
>   activesupport (4.1.4) lib/active_support/dependencies.rb:518:in `load_missing_constant'
>   activesupport (4.1.4) lib/active_support/dependencies.rb:180:in`const_missing'
>    () Users/paulo/.rvm/gems/ruby-2.1.2@auth/bundler/gems/CASino-a2ec29c1a104/app/processors/casino/processor_concern/two_factor_authenticators.rb:12:in `validate_one_time_password'
>    () Users/paulo/.rvm/gems/ruby-2.1.2@auth/bundler/gems/CASino-a2ec29c1a104/app/processors/casino/second_factor_authentication_acceptor_processor.rb:24:in`process'
>    () Users/paulo/.rvm/gems/ruby-2.1.2@auth/bundler/gems/CASino-a2ec29c1a104/app/controllers/casino/sessions_controller.rb:30:in `validate_otp'
