### PR TITLE
Set window.CASino.baseUrl to root_path

### DIFF
--- a/app/assets/javascripts/casino/application.js.erb
+++ b/app/assets/javascripts/casino/application.js.erb
@@ -1,7 +1,7 @@
 // Place all the behaviors and hooks related to the matching controller here.
 (function(win) {
   if(!win.CASino) {
-    win.CASino = { baseUrl: '/' };
+    win.CASino = { baseUrl: '<%= CASino::Engine.routes.url_helpers.root_path %>' };
   }
 
   win.CASino.url = function(path) {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,6 @@
   <title><%= CASino.config.frontend[:sso_name] %></title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
   <%= stylesheet_link_tag    "application", :media => "all" %>
-  <%= javascript_tag         "window.CASino = { baseUrl: '#{root_path}' };" %>
   <%= javascript_include_tag "application" %>
   <%= csrf_meta_tags %>
   <%= favicon_link_tag 'favicon.png', type: 'image/png' %>


### PR DESCRIPTION
I think this is a more robust way to define the baseUrl, so you don't forget it if you customize the layout. 