### PR TITLE
External authenticator implementation (Issue #32)

### DIFF
--- a/app/assets/stylesheets/casino.scss
+++ b/app/assets/stylesheets/casino.scss
@@ -270,6 +270,18 @@ table {
   }
 }
 
+/// LOGIN EXTERNAL INLINE LIST ///
+#external_list
+{
+  margin: 0;
+  padding: 0;
+  margin-right: 10px;
+  list-style-type: none;
+  text-align: left;
+
+  li { display: inline-block; }
+}
+
 /// SESSIONS ///
 .sessions, .logout {
   width: 800px;

--- a/app/authenticators/casino/static_external_authenticator.rb
+++ b/app/authenticators/casino/static_external_authenticator.rb
@@ -1,0 +1,28 @@
+require 'casino/external_authenticator'
+
+# The external static authenticator is just a simple example.
+# Never use this authenticator in a production environment!
+class CASino::StaticExternalAuthenticator < CASino::Authenticator
+
+  # @param [Hash] options
+  def initialize(options)
+    @users = options[:users] || {}
+  end
+
+  def validate(params, cookies)
+    token = :"#{cookies[:token]}"
+    if @users.include?(token)
+      {
+        username: @users[token][:username],
+        extra_attributes: @users[token].except(:token)
+      }
+    else
+      false
+    end
+  end
+
+  def view
+    return nil
+  end
+
+end

--- a/app/controllers/casino/sessions_controller.rb
+++ b/app/controllers/casino/sessions_controller.rb
@@ -11,7 +11,7 @@ class CASino::SessionsController < CASino::ApplicationController
   end
 
   def create
-    processor(:LoginCredentialAcceptor).process(params, request.user_agent)
+    processor(:LoginCredentialAcceptor).process(params, cookies, request.user_agent)
   end
 
   def destroy

--- a/app/listeners/casino/login_credential_acceptor_listener.rb
+++ b/app/listeners/casino/login_credential_acceptor_listener.rb
@@ -15,14 +15,14 @@ class CASino::LoginCredentialAcceptorListener < CASino::Listener
     @controller.render 'validate_otp'
   end
 
-  def invalid_login_credentials(login_ticket)
+  def invalid_login_credentials(login_ticket, external_authenticators)
     @controller.flash.now[:error] = I18n.t('login_credential_acceptor.invalid_login_credentials')
-    rerender_login_page(login_ticket)
+    rerender_login_page(login_ticket, external_authenticators)
   end
 
-  def invalid_login_ticket(login_ticket)
+  def invalid_login_ticket(login_ticket, external_authenticators)
     @controller.flash.now[:error] = I18n.t('login_credential_acceptor.invalid_login_ticket')
-    rerender_login_page(login_ticket)
+    rerender_login_page(login_ticket, external_authenticators)
   end
 
   def service_not_allowed(service)
@@ -31,8 +31,9 @@ class CASino::LoginCredentialAcceptorListener < CASino::Listener
   end
 
   private
-  def rerender_login_page(login_ticket)
+  def rerender_login_page(login_ticket, external_authenticators)
     assign(:login_ticket, login_ticket)
+    assign(:external_authenticators, external_authenticators)
     @controller.render 'new', status: 403
   end
 end

--- a/app/listeners/casino/login_credential_requestor_listener.rb
+++ b/app/listeners/casino/login_credential_requestor_listener.rb
@@ -1,8 +1,9 @@
 require_relative 'listener'
 
 class CASino::LoginCredentialRequestorListener < CASino::Listener
-  def user_not_logged_in(login_ticket)
+  def user_not_logged_in(login_ticket, external_authenticators)
     assign(:login_ticket, login_ticket)
+    assign(:external_authenticators, external_authenticators)
     @controller.cookies.delete :tgt
   end
 

--- a/app/processors/casino/login_credential_requestor_processor.rb
+++ b/app/processors/casino/login_credential_requestor_processor.rb
@@ -4,6 +4,7 @@ class CASino::LoginCredentialRequestorProcessor < CASino::Processor
   include CASino::ProcessorConcern::LoginTickets
   include CASino::ProcessorConcern::ServiceTickets
   include CASino::ProcessorConcern::TicketGrantingTickets
+  include CASino::ProcessorConcern::Authentication
 
   # Use this method to process the request.
   #
@@ -51,7 +52,8 @@ class CASino::LoginCredentialRequestorProcessor < CASino::Processor
       @listener.user_logged_in(@service_url)
     else
       login_ticket = acquire_login_ticket
-      @listener.user_not_logged_in(login_ticket)
+      external_authenticators = authenticators(:external_authenticators)
+      @listener.user_not_logged_in(login_ticket, external_authenticators)
     end
   end
 

--- a/app/views/casino/sessions/_external.html.erb
+++ b/app/views/casino/sessions/_external.html.erb
@@ -1,0 +1,15 @@
+<% if @external_authenticators.any? %>
+  <ul id="external_list">
+  <% @external_authenticators.each do |authenticator_name, authenticator| %>
+    <% unless authenticator.view.nil? %>
+      <li>
+        <%= form_tag(login_path, method: :post) do %>
+          <%= hidden_field_tag :lt, @login_ticket.ticket %>
+          <%= hidden_field_tag :external, authenticator_name %>
+          <%= render authenticator.view, :authenticator => authenticator %>
+        <% end %>
+      </li>
+    <% end %>
+  <% end %>
+  </ul>
+<% end%>

--- a/app/views/casino/sessions/new.html.erb
+++ b/app/views/casino/sessions/new.html.erb
@@ -24,6 +24,7 @@
         <% end %>
         <%= button_tag t('login.label_button'), :class => 'button' %>
       <% end %>
+      <%= render 'external' %>
     </div>
   </div>
   <%= render 'footer' %>

--- a/lib/casino.rb
+++ b/lib/casino.rb
@@ -6,6 +6,7 @@ module CASino
 
   defaults = {
     authenticators: HashWithIndifferentAccess.new,
+    external_authenticators: HashWithIndifferentAccess.new,
     logger: Rails.logger,
     frontend: HashWithIndifferentAccess.new(
       sso_name: 'CASino',

--- a/lib/casino/external_authenticator.rb
+++ b/lib/casino/external_authenticator.rb
@@ -1,0 +1,14 @@
+module CASino
+  class ExternalAuthenticator
+    class ExternalAuthenticatorError < StandardError; end
+
+    def validate(params, cookies)
+      raise NotImplementedError, "This method must be implemented by a class extending #{self.class}"
+    end
+
+    def view
+      raise NotImplementedError, "This method must be implemented by a class extending #{self.class}"
+    end
+
+  end
+end

--- a/spec/authenticator/base_spec.rb
+++ b/spec/authenticator/base_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 require 'casino/authenticator'
+require 'casino/external_authenticator'
 
 describe CASino::Authenticator do
   subject {
@@ -10,6 +11,24 @@ describe CASino::Authenticator do
   context '#validate' do
     it 'raises an error' do
       expect { subject.validate(nil, nil) }.to raise_error(NotImplementedError)
+    end
+  end
+end
+
+describe CASino::ExternalAuthenticator do
+  subject {
+    CASino::ExternalAuthenticator.new
+  }
+
+  context '#validate' do
+    it 'raises an error' do
+      expect { subject.validate(nil, nil) }.to raise_error(NotImplementedError)
+    end
+  end
+
+  context '#view' do
+    it 'raises an error' do
+      expect { subject.view }.to raise_error(NotImplementedError)
     end
   end
 end

--- a/spec/controllers/listener/login_credential_acceptor_spec.rb
+++ b/spec/controllers/listener/login_credential_acceptor_spec.rb
@@ -47,6 +47,7 @@ describe CASino::LoginCredentialAcceptorListener do
     context "##{method}" do
       let(:login_ticket) { Object.new }
       let(:flash) { ActionDispatch::Flash::FlashHash.new }
+      let(:external_authenticators) { { :static => {} } }
 
       before(:each) do
         controller.stub(:render)
@@ -55,16 +56,21 @@ describe CASino::LoginCredentialAcceptorListener do
 
       it 'tells the controller to render the new template' do
         controller.should_receive(:render).with('new', status: 403)
-        listener.send(method, login_ticket)
+        listener.send(method, login_ticket, external_authenticators)
       end
 
       it 'assigns a new login ticket' do
-        listener.send(method, login_ticket)
+        listener.send(method, login_ticket, external_authenticators)
         controller.instance_variable_get(:@login_ticket).should == login_ticket
       end
 
+      it 'receives external authenticators' do
+        listener.send(method, login_ticket, external_authenticators)
+        controller.instance_variable_get(:@external_authenticators).should == external_authenticators
+      end
+
       it 'should add an error message' do
-        listener.send(method, login_ticket)
+        listener.send(method, login_ticket, external_authenticators)
         flash[:error].should == I18n.t("login_credential_acceptor.#{method}")
       end
     end

--- a/spec/controllers/listener/login_credential_requestor_spec.rb
+++ b/spec/controllers/listener/login_credential_requestor_spec.rb
@@ -4,17 +4,23 @@ describe CASino::LoginCredentialRequestorListener do
   include CASino::Engine.routes.url_helpers
   let(:controller) { Struct.new(:cookies).new(cookies: {}) }
   let(:listener) { described_class.new(controller) }
+  let(:external_authenticators) { { :static => {} } }
 
   describe '#user_not_logged_in' do
     let(:login_ticket) { Object.new }
     it 'assigns the login ticket' do
-      listener.user_not_logged_in(login_ticket)
+      listener.user_not_logged_in(login_ticket, external_authenticators)
       controller.instance_variable_get(:@login_ticket).should == login_ticket
+    end
+
+    it 'receives external authenticators' do
+      listener.user_not_logged_in(login_ticket, external_authenticators)
+      controller.instance_variable_get(:@external_authenticators).should == external_authenticators
     end
 
     it 'deletes an existing ticket-granting ticket cookie' do
       controller.cookies = { tgt: 'TGT-12345' }
-      listener.user_not_logged_in(login_ticket)
+      listener.user_not_logged_in(login_ticket, external_authenticators)
       controller.cookies[:tgt].should be_nil
     end
   end

--- a/spec/dummy/config/cas.yml
+++ b/spec/dummy/config/cas.yml
@@ -18,7 +18,14 @@ defaults: &defaults
           testuser:
             password: "foobar123"
             name: "Test User"
-
+  external_authenticators:
+    external_static:
+      class: "CASino::StaticExternalAuthenticator"
+      options:
+        users:
+          foobar123:
+            username: "foobar"
+            name: "Test User"
 development:
   <<: *defaults
 

--- a/spec/processor/login_credential_requestor_spec.rb
+++ b/spec/processor/login_credential_requestor_spec.rb
@@ -20,7 +20,7 @@ describe CASino::LoginCredentialRequestorProcessor do
 
     context 'when logged out' do
       it 'calls the #user_not_logged_in method on the listener' do
-        listener.should_receive(:user_not_logged_in).with(kind_of(CASino::LoginTicket))
+        listener.should_receive(:user_not_logged_in).with(kind_of(CASino::LoginTicket), kind_of(Hash))
         processor.process
       end
 
@@ -39,7 +39,7 @@ describe CASino::LoginCredentialRequestorProcessor do
           let(:params) { { gateway: 'true' } }
 
           it 'calls the #user_not_logged_in method on the listener' do
-            listener.should_receive(:user_not_logged_in).with(kind_of(CASino::LoginTicket))
+            listener.should_receive(:user_not_logged_in).with(kind_of(CASino::LoginTicket), kind_of(Hash))
             processor.process
           end
         end
@@ -59,7 +59,7 @@ describe CASino::LoginCredentialRequestorProcessor do
         let(:ticket_granting_ticket) { FactoryGirl.create :ticket_granting_ticket, :awaiting_two_factor_authentication }
 
         it 'calls the #user_not_logged_in method on the listener' do
-          listener.should_receive(:user_not_logged_in).with(kind_of(CASino::LoginTicket))
+          listener.should_receive(:user_not_logged_in).with(kind_of(CASino::LoginTicket), kind_of(Hash))
           processor.process(nil, cookies, user_agent)
         end
       end
@@ -71,7 +71,7 @@ describe CASino::LoginCredentialRequestorProcessor do
         end
 
         it 'calls the #user_not_logged_in method on the listener' do
-          listener.should_receive(:user_not_logged_in).with(kind_of(CASino::LoginTicket))
+          listener.should_receive(:user_not_logged_in).with(kind_of(CASino::LoginTicket), kind_of(Hash))
           processor.process(nil, cookies, user_agent)
         end
       end
@@ -93,7 +93,7 @@ describe CASino::LoginCredentialRequestorProcessor do
 
         context 'with renew parameter' do
           it 'calls the #user_not_logged_in method on the listener' do
-            listener.should_receive(:user_not_logged_in).with(kind_of(CASino::LoginTicket))
+            listener.should_receive(:user_not_logged_in).with(kind_of(CASino::LoginTicket), kind_of(Hash))
             processor.process(params.merge({ renew: 'true' }), cookies)
           end
         end
@@ -135,7 +135,7 @@ describe CASino::LoginCredentialRequestorProcessor do
           let(:user_agent) { 'FooBar 1.0' }
 
           it 'calls the #user_not_logged_in method on the listener' do
-            listener.should_receive(:user_not_logged_in).with(kind_of(CASino::LoginTicket))
+            listener.should_receive(:user_not_logged_in).with(kind_of(CASino::LoginTicket), kind_of(Hash))
             processor.process(nil, cookies, user_agent)
           end
         end


### PR DESCRIPTION
I have implemented external authenticator support for CASino based on the description you provided on [Issue 32](https://github.com/rbCAS/CASino/issues/32):

> pencil commented on Mar 19, 2014
> No, it does not fit into the current CASino workflow. The best way would probably be to start off with an > "external authenticator" abstraction. Then display a button for all external authenticators at the login page.

My needs were specifically for Facebook authentication using their JavaScript SDK. I have created a Facebook authenticator to work with this external authentication implementation, which you can view [here](https://github.com/craigweston/casino-facebook_authenticator).

### Configuration:
I have added a new section to the ```cas.yml``` file which mimics the existing authenticator section.  

An example of this:

```
  external_authenticators:
    facebook:
      authenticator: "Facebook"
      options:
        connection:
          adapter: "mysql2"
          host: "localhost"
          username: "username"
          password: "password"
          database: "CASinoApp"
        app_id: "111111111111"
        app_secret: “11111111111111111”
        user_table: "users"
        username_column: "username"
        facebook_id_column: "facebook_id"
```

### Implementation:

The external authenticators were designed with the expectation that each will provide a view and a validation function.

External authenticator base class:
```
  class ExternalAuthenticator
    def validate(params, cookies)
      raise NotImplementedError, "This method must be implemented by a class extending #{self.class}"
    end
    def view
      raise NotImplementedError, "This method must be implemented by a class extending #{self.class}"
    end
  end
```

#### View:
The view function provides the path to the view, used for rendering the button on the login page.

An example of this taken from my *casino_facebook-authenticator*:
```
  def view
    @options[:view] || '/facebook_login.html.erb'
  end
```

Because the view is embedded in the external authenticator itself, it is expected that the external authenticators will be implemented as minimal Rails Engines.

#### Validation
Unlike the current validation function that relies on a username and password, I have made the external authenticator's validation function require request parameters and cookies. I figured this would provide the most flexibility while still providing the necessary data to support most authentication services. 

```
  # @param [Hash] parameters
  # @param [Hash] cookies
  def validate(params, cookies)
  ...
  end
```
As an example, my Facebook authenticator expects the access token to be generated on the client side and then passed via POST parameters to the server for server side verification. The assumption is that other external authenticators would use a similar client side approach for generating the necessary authentication tokens or cookies required.

#### Processor Concern - Authentication
In order to support this new validation functionality, I had to make changes to the *app/processors/casino/processor_concern/authentication.rb*. 

There are now two different validation functions:
```
      def validate_login_credentials(username, password)
        validate :authenticators do |authenticator_name, authenticator|
          authenticator.validate(username, password)
        end
      end

      def validate_external_credentials(params, cookies)
        validate :external_authenticators do |authenticator_name, authenticator|
          if authenticator_name == params[:external]
            authenticator.validate(params, cookies)
          end
        end
      end
```
You'll notice that the ```validate_external_credentials``` only validates for the authenticator that was submitted via the ```external``` parameter.

The common functionality has been placed in the ```validate``` function:

```
      def validate(type, &validator)
        authentication_result = nil
        authenticators(type).each do |authenticator_name, authenticator|
          begin
            data = validator.call(authenticator_name, authenticator)
          rescue CASino::Authenticator::AuthenticatorError => e
            Rails.logger.error "Authenticator '#{authenticator_name}' (#{authenticator.class}) raised an error: #{e}"
          end
          if data
            authentication_result = { authenticator: authenticator_name, user_data: data }
            Rails.logger.info("Credentials for username '#{data[:username]}' successfully validated using authenticator '#{authenticator_name}' (#{authenticator.class})")
            break
          end
        end
        authentication_result
      end
```

Because there are now two different types of authenticators, I had to also change the ```authenticators``` method signature to take an authenticator type. The cached ```@authenticators``` has also been changed to be a hash, which is keyed on authenticator type.

```
      def authenticators(type)
        @authenticators ||= {}
        return @authenticators[type] if @authenticators.has_key?(type)
        @authenticators[type] = begin
          CASino.config[type].each do |name, auth|
            next unless auth.is_a?(Hash)

            authenticator = if auth[:class]
              auth[:class].constantize
            else
              load_authenticator(auth[:authenticator])
            end

            CASino.config[type][name] = authenticator.new(auth[:options])
          end
        end
      end
```

#### Login Credential Acceptor Processor
The trigger that is used to know when to invoke an external authenticator or a regular authenticator happens based on whether the external parameter is submitted. This check happens in the */login_credential_acceptor_processor.rb*.

```
  def validate_credentials
    if @params[:external]
      validate_external_credentials(@params, @cookies)
    else
      validate_login_credentials(@params[:username], @params[:password])
    end
  end
```

### Login Page
The external authenticator buttons are rendered on the login page within an inline list. Each view is wrapped in its own form, containing the login ticket and external hidden inputs.

```
      <li>
        <%= form_tag(login_path, method: :post) do %>
          <%= hidden_field_tag :lt, @login_ticket.ticket %>
          <%= hidden_field_tag :external, authenticator_name %>
          <%= render authenticator.view %>
        <% end %>
      </li>
``` 
The idea being that each authenticator will submit the wrapping form when necessary, including any additional data that may be needed on the server side. 

As an example, my Facebook authenticator submits the form via JavaScript after the Facebook login process has completed and the access token has been added to the form dynamically as a hidden input.

#### External Authenticator List
Because the view needs to render a view for each of the authenticators, I pass a list of external authenticators to the view via the ```@external_authenticators```. This list is passed from the processor, to the listener and then to the view. This is not ideal, as it does introduce some repetitiveness in the processor, but I needed to be able to reuse the *processor_concern/authenticators.rb's* ```authenticators``` method, and therefore keeping this call in the processor made sense.

Example (*login_credential_requestor_processor.rb*):

```
  def handle_not_logged_in
      ...
      login_ticket = acquire_login_ticket
      external_authenticators = authenticators(:external_authenticators)
      @listener.user_not_logged_in(login_ticket, external_authenticators)
      ...
  end
```

Please let me know if you have any questions, concerns or changes. I look forward to hearing your input.

Thank you.
