### PR TITLE
Use Base64.urlsafe_decode64 for auth tokens

### DIFF
--- a/app/controllers/casino/auth_tokens_controller.rb
+++ b/app/controllers/casino/auth_tokens_controller.rb
@@ -26,7 +26,7 @@ class CASino::AuthTokensController < CASino::ApplicationController
 
   def base64_decode(data)
     begin
-      Base64.strict_decode64(data)
+      Base64.urlsafe_decode64(data)
     rescue
       ''
     end


### PR DESCRIPTION
Previous use of [Base64.strict_decode64](http://ruby-doc.org/stdlib-1.9.3/libdoc/base64/rdoc/Base64.html#method-i-strict_decode64) had issues with `+`'s getting
decoded as spaces. [Base64.urlsafe_decode64](http://ruby-doc.org/stdlib-1.9.3/libdoc/base64/rdoc/Base64.html#method-i-urlsafe_decode64) prevents these issues by not using `+` or `/` as characters.

The wiki example would need to be updated to use [Base64.urlsafe_encode64](http://ruby-doc.org/stdlib-1.9.3/libdoc/base64/rdoc/Base64.html#method-i-urlsafe_encode64) as well.