### PR TITLE
Uppercase ldap authenticator in cas.yml template

### DIFF
--- a/lib/generators/casino/install/templates/cas.yml
+++ b/lib/generators/casino/install/templates/cas.yml
@@ -35,7 +35,7 @@ production:
   <<: *defaults
   authenticators:
     my_company_ldap:
-      authenticator: "ldap"
+      authenticator: "LDAP"
       options:
         host: "localhost"
         port: 12445


### PR DESCRIPTION
Lowercase authenticator name generates error: 

```
NameError in CASino::SessionsController#create

Failed to load authenticator 'ldap'. The authenticator class must be defined in the CASino namespace. Error: uninitialized constant CASino::LdapAuthenticator
```