### PR TITLE
Handle Errno::ETIMEOUT when sending single sign out notifications

### DIFF
--- a/app/models/casino/service_ticket/single_sign_out_notifier.rb
+++ b/app/models/casino/service_ticket/single_sign_out_notifier.rb
@@ -37,7 +37,7 @@ class CASino::ServiceTicket::SingleSignOutNotifier
       Rails.logger.warn "Service #{url} responded to logout notification with code '#{result.status}'!"
       false
     end
-  rescue Faraday::Error::ClientError => error
+  rescue Faraday::Error::ClientError, Errno::ETIMEDOUT => error
     Rails.logger.warn "Failed to send logout notification to service #{url} due to #{error}"
     false
   end

--- a/spec/model/service_ticket/single_sign_out_notifier_spec.rb
+++ b/spec/model/service_ticket/single_sign_out_notifier_spec.rb
@@ -56,6 +56,16 @@ describe CASino::ServiceTicket::SingleSignOutNotifier do
           notifier.notify.should == false
         end
       end
+
+      context 'network timeout' do
+        before(:each) do
+          stub_request(:post, service).to_raise Errno::ETIMEDOUT
+        end
+
+        it 'returns false' do
+          notifier.notify.should == false
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Under some circumstances Errno::ETIMEOUT gets raised instead of Timeout::Error.
We don't want this to cause failures, so let's catch and log it instead of
allowing it to propogate up.

We are seeing this happen in our environment when a host is down completely.