### PR TITLE
Remove acronym inflector for CAS

### DIFF
--- a/lib/casino/inflections.rb
+++ b/lib/casino/inflections.rb
@@ -2,6 +2,5 @@
 # the Railtie is going to declare a table_name_suffix based upon the name of the
 # Railtie. Without this definition, the Railtie would use 'ca_s_ino'
 ActiveSupport::Inflector.inflections do |inflect|
-  inflect.acronym 'CAS'
   inflect.acronym 'CASino'
 end


### PR DESCRIPTION
Host applications might be using "Cas" as a constant and not using "CAS"

This references issue [101](https://github.com/rbCAS/CASino/issues/101)

In that scenario, simply including the CASino Engine into that application will cause the entire app to "blow up".

In accordance with the "Principle of least astonishment", CASino should not mandate how certain words are inflected unless they are entirely unique to CASino.

* Removes the inflection rule for the CAS acronym

* There was no need to edit any code, CAS is not used in the CASino code base by itself