### PR TITLE
Add context parameter for authenticators

### DIFF
--- a/app/controllers/casino/sessions_controller.rb
+++ b/app/controllers/casino/sessions_controller.rb
@@ -20,7 +20,7 @@ class CASino::SessionsController < CASino::ApplicationController
   end
 
   def create
-    validation_result = validate_login_credentials(params[:username], params[:password])
+    validation_result = validate_login_credentials(params[:username], params[:password], params[:content])
     if !validation_result
       show_login_error I18n.t('login_credential_acceptor.invalid_login_credentials')
     else

--- a/app/processors/casino/authentication_processor.rb
+++ b/app/processors/casino/authentication_processor.rb
@@ -3,11 +3,17 @@ require 'casino/authenticator'
 module CASino::AuthenticationProcessor
   extend ActiveSupport::Concern
 
-  def validate_login_credentials(username, password)
+  def validate_login_credentials(username, password, context = {})
     authentication_result = nil
     authenticators.each do |authenticator_name, authenticator|
       begin
-        data = authenticator.validate(username, password)
+        credentials = [ username, password, context ]
+
+        # Old authenticators that don't accept a 3rd context parameter will have a validate
+        # method that only accepts 2 arguments, so check for that.
+        credentials.pop if authenticator.class.instance_method(:validate).arity == 2
+
+        data = authenticator.validate(*credentials)
       rescue CASino::Authenticator::AuthenticatorError => e
         Rails.logger.error "Authenticator '#{authenticator_name}' (#{authenticator.class}) raised an error: #{e}"
       end


### PR DESCRIPTION
Hi there,

When logging in my users I also need a parameter for which country they want to log into. Instead of just adding a third parameter called country and keep it as a local branch I thought I'd make it more generic in the hope you'd merge this into CASino?

Anyway, I've added a third parameter to authenticators' #validate method called context, which could just be a Hash or really any data that's specific to the particular authenticator class you're using.
