### PR TITLE
Added option to require service rules when a service URL is specified

### DIFF
--- a/app/models/casino/service_rule.rb
+++ b/app/models/casino/service_rule.rb
@@ -5,7 +5,7 @@ class CASino::ServiceRule < ActiveRecord::Base
 
   def self.allowed?(service_url)
     rules = self.where(enabled: true)
-    if rules.empty?
+    if rules.empty? && !CASino.config.require_service_rules
       true
     else
       rules.any? { |rule| rule.allows?(service_url) }

--- a/lib/casino.rb
+++ b/lib/casino.rb
@@ -6,6 +6,7 @@ module CASino
 
   defaults = {
     authenticators: HashWithIndifferentAccess.new,
+    require_service_rules: false,
     logger: Rails.logger,
     frontend: HashWithIndifferentAccess.new(
       sso_name: 'CASino',


### PR DESCRIPTION
We don't want to allow authentication from any service if no rules have been setup. The default is to allow this, but the new option makes sure that a rule is matched -- otherwise, login is disallowed.