### PR TITLE
Add context with a simple `builder`

### DIFF
--- a/app/controllers/casino/sessions_controller.rb
+++ b/app/controllers/casino/sessions_controller.rb
@@ -20,7 +20,7 @@ class CASino::SessionsController < CASino::ApplicationController
   end
 
   def create
-    validation_result = validate_login_credentials(params[:username], params[:password])
+    validation_result = validate_login_credentials(params[:username], params[:password], params[:content])
     if !validation_result
       show_login_error I18n.t('login_credential_acceptor.invalid_login_credentials')
     else

--- a/app/controllers/casino/sessions_controller.rb
+++ b/app/controllers/casino/sessions_controller.rb
@@ -20,7 +20,7 @@ class CASino::SessionsController < CASino::ApplicationController
   end
 
   def create
-    validation_result = validate_login_credentials(params[:username], params[:password], params[:content])
+    validation_result = validate_login_credentials(params[:username], params[:password], current_authenticator_context)
     if !validation_result
       show_login_error I18n.t('login_credential_acceptor.invalid_login_credentials')
     else

--- a/app/helpers/casino/sessions_helper.rb
+++ b/app/helpers/casino/sessions_helper.rb
@@ -23,6 +23,10 @@ module CASino::SessionsHelper
     tgt.user
   end
 
+  def current_authenticator_context
+    CASino.config.authenticator_context_builder.call(params, request)
+  end
+  
   def ensure_signed_in
     redirect_to login_path unless signed_in?
   end

--- a/app/processors/casino/authentication_processor.rb
+++ b/app/processors/casino/authentication_processor.rb
@@ -3,7 +3,7 @@ require 'casino/authenticator'
 module CASino::AuthenticationProcessor
   extend ActiveSupport::Concern
 
-  def validate_login_credentials(username, password, context = {})
+  def validate_login_credentials(username, password, context = nil)
     authentication_result = nil
     authenticators.each do |authenticator_name, authenticator|
       begin

--- a/app/processors/casino/authentication_processor.rb
+++ b/app/processors/casino/authentication_processor.rb
@@ -3,11 +3,17 @@ require 'casino/authenticator'
 module CASino::AuthenticationProcessor
   extend ActiveSupport::Concern
 
-  def validate_login_credentials(username, password)
+  def validate_login_credentials(username, password, context = {})
     authentication_result = nil
     authenticators.each do |authenticator_name, authenticator|
       begin
-        data = authenticator.validate(username, password)
+        credentials = [ username, password, context ]
+
+        # Old authenticators that don't accept a 3rd context parameter will have a validate
+        # method that only accepts 2 arguments, so check for that.
+        credentials.pop if authenticator.class.instance_method(:validate).arity == 2
+
+        data = authenticator.validate(*credentials)
       rescue CASino::Authenticator::AuthenticatorError => e
         Rails.logger.error "Authenticator '#{authenticator_name}' (#{authenticator.class}) raised an error: #{e}"
       end

--- a/lib/casino.rb
+++ b/lib/casino.rb
@@ -6,6 +6,7 @@ module CASino
 
   defaults = {
     authenticators: HashWithIndifferentAccess.new,
+    authenticator_context_builder: ->(params, request){ },
     logger: Rails.logger,
     frontend: HashWithIndifferentAccess.new(
       sso_name: 'CASino',


### PR DESCRIPTION
Built off of @meanphil's PR https://github.com/rbCAS/CASino/pull/126. Rather than use a request `param`, simply build the context using a `Proc` or `lambda`. This allows us to authenticate based on the requested host, because we use subdomains to silo users.