### PR TITLE
Specify a custom User superclass to use

### DIFF
--- a/app/models/casino/ticket_granting_ticket.rb
+++ b/app/models/casino/ticket_granting_ticket.rb
@@ -5,7 +5,7 @@ class CASino::TicketGrantingTicket < ActiveRecord::Base
 
   self.ticket_prefix = 'TGC'.freeze
 
-  belongs_to :user
+  belongs_to :user, class_name: CASino.user_class.name
   has_many :service_tickets, dependent: :destroy
 
   scope :active, -> { where(awaiting_two_factor_authentication: false).order('updated_at DESC') }

--- a/app/models/casino/two_factor_authenticator.rb
+++ b/app/models/casino/two_factor_authenticator.rb
@@ -1,6 +1,6 @@
 
 class CASino::TwoFactorAuthenticator < ActiveRecord::Base
-  belongs_to :user
+  belongs_to :user, class_name: CASino.user_class.name
 
   scope :active, -> { where(active: true) }
 

--- a/app/processors/casino/ticket_granting_ticket_processor.rb
+++ b/app/processors/casino/ticket_granting_ticket_processor.rb
@@ -38,7 +38,7 @@ module CASino::TicketGrantingTicketProcessor
   end
 
   def load_or_initialize_user(authenticator, username, extra_attributes)
-    user = CASino::User
+    user = CASino.user_class
       .where(authenticator: authenticator, username: username)
       .first_or_initialize
     user.extra_attributes = extra_attributes

--- a/config/cas.yml
+++ b/config/cas.yml
@@ -1,4 +1,5 @@
 defaults: &defaults
+  user_class_name: 'CASino::User'
   service_ticket:
     lifetime_unconsumed: 299
   authenticators:

--- a/lib/casino.rb
+++ b/lib/casino.rb
@@ -5,6 +5,7 @@ module CASino
   include ActiveSupport::Configurable
 
   defaults = {
+    user_class_name: 'CASino::User',
     authenticators: HashWithIndifferentAccess.new,
     require_service_rules: false,
     logger: Rails.logger,
@@ -51,4 +52,8 @@ module CASino
   }
 
   self.config.merge! defaults.deep_dup
+
+  def self.user_class
+    config.user_class_name.constantize
+  end
 end

--- a/lib/casino/tasks/user.rake
+++ b/lib/casino/tasks/user.rake
@@ -4,7 +4,7 @@ namespace :casino do
   namespace :user do
     desc 'Search users by name.'
     task :search, [:query] => :environment do |task, args|
-      users = CASino::User.where('username LIKE ?', "%#{args[:query]}%")
+      users = CASino.user_class.where('username LIKE ?', "%#{args[:query]}%")
       if users.any?
         headers = ['User ID', 'Username', 'Authenticator', 'Two-factor authentication enabled?']
         table = Terminal::Table.new :headings => headers do |t|
@@ -21,8 +21,8 @@ namespace :casino do
 
     desc 'Deactivate two-factor authentication for a user.'
     task :deactivate_two_factor_authentication, [:user_id] => :environment do |task, args|
-      if CASino::User.find(args[:user_id]).active_two_factor_authenticator
-        CASino::User.find(args[:user_id]).active_two_factor_authenticator.destroy
+      if CASino.user_class.find(args[:user_id]).active_two_factor_authenticator
+        CASino.user_class.find(args[:user_id]).active_two_factor_authenticator.destroy
         puts "Successfully deactivated two-factor authentication for user ##{args[:user_id]}."
       else
         puts "No two-factor authenticator found for user ##{args[:user_id]}."

--- a/spec/controllers/service_and_proxy_tickets_controller_spec.rb
+++ b/spec/controllers/service_and_proxy_tickets_controller_spec.rb
@@ -30,7 +30,7 @@ shared_examples_for 'a service ticket validator' do
     context 'with an unconsumed service ticket' do
       context 'with extra attributes using strings as keys' do
         before(:each) do
-          CASino::User.any_instance.stub(:extra_attributes).and_return({ "id" => 1234 })
+          CASino.user_class.any_instance.stub(:extra_attributes).and_return({ "id" => 1234 })
         end
 
         it 'includes the extra attributes' do
@@ -41,7 +41,7 @@ shared_examples_for 'a service ticket validator' do
 
       context 'with extra attributes using array as value' do
         before(:each) do
-          CASino::User.any_instance.stub(:extra_attributes).and_return({ "memberOf" => [ "test", "yolo" ] })
+          CASino.user_class.any_instance.stub(:extra_attributes).and_return({ "memberOf" => [ "test", "yolo" ] })
         end
 
         it 'includes all values' do

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -231,7 +231,7 @@ describe CASino::SessionsController do
         end
 
         context 'with two-factor authentication enabled' do
-          let!(:user) { CASino::User.create! username: username, authenticator: authenticator }
+          let!(:user) { CASino.user_class.create! username: username, authenticator: authenticator }
           let!(:two_factor_authenticator) { FactoryGirl.create :two_factor_authenticator, user: user }
 
           it 'renders the validate_otp template' do
@@ -283,24 +283,24 @@ describe CASino::SessionsController do
             it 'generates exactly one user' do
               lambda do
                 post :create, request_options
-              end.should change(CASino::User, :count).by(1)
+              end.should change(CASino.user_class, :count).by(1)
             end
 
             it 'sets the users attributes' do
               post :create, request_options
-              user = CASino::User.last
+              user = CASino.user_class.last
               user.username.should == username
               user.authenticator.should == authenticator
             end
           end
 
           context 'when the user already exists' do
-            let!(:user) { CASino::User.create! username: username, authenticator: authenticator }
+            let!(:user) { CASino.user_class.create! username: username, authenticator: authenticator }
 
             it 'does not regenerate the user' do
               lambda do
                 post :create, request_options
-              end.should_not change(CASino::User, :count)
+              end.should_not change(CASino.user_class, :count)
             end
 
             it 'updates the extra attributes' do

--- a/spec/support/factories/user_factory.rb
+++ b/spec/support/factories/user_factory.rb
@@ -1,7 +1,7 @@
 require 'factory_girl'
 
 FactoryGirl.define do
-  factory :user, class: CASino::User do
+  factory :user, class: CASino.user_class do
     authenticator 'test'
     sequence(:username) do |n|
       "test#{n}"


### PR DESCRIPTION
Create a configurable way to specify a superclass for `CASino::User`. This allows CASino to become an extension of an existing application, where the "user" is the joining model for many other relationships. This is a clean way to make sure the "user" association on other CASino models are of the proper user class as well.