### PR TITLE
enforce two-factor usage outside whitelisted ip ranges.

### DIFF
--- a/app/helpers/casino/sessions_helper.rb
+++ b/app/helpers/casino/sessions_helper.rb
@@ -54,7 +54,11 @@ module CASino::SessionsHelper
   def handle_signed_in(tgt, options = {})
     if tgt.awaiting_two_factor_authentication?
       @ticket_granting_ticket = tgt
-      render 'casino/sessions/validate_otp'
+      if @ticket_granting_ticket.user.active_two_factor_authenticator
+        render 'casino/sessions/validate_otp'
+      else
+        render 'casino/sessions/two_factor_not_configured'
+      end
     else
       if params[:service].present?
         begin

--- a/app/models/casino/ip_whitelist.rb
+++ b/app/models/casino/ip_whitelist.rb
@@ -1,0 +1,21 @@
+class CASino::IPWhitelist
+  def initialize(entries)
+    @entries = entries
+  end
+
+  def include?(ip)
+    parsed.any? { |entry| entry.include?(ip) }
+  end
+
+  private
+  def parsed
+    @parsed ||= @entries.map do |entry|
+      case entry
+      when String
+        IPAddr.new(entry)
+      when Array
+        (IPAddr.new(entry[0])..IPAddr.new(entry[1]))
+      end
+    end
+  end
+end

--- a/app/views/casino/sessions/two_factor_not_configured.html.erb
+++ b/app/views/casino/sessions/two_factor_not_configured.html.erb
@@ -1,0 +1,14 @@
+<div class="container">
+  <div class="logout box">
+
+    <div class="info">
+      <h1><%= t 'two_factor_not_configured.title' %></h1>
+      <p>
+        <%= t 'two_factor_not_configured.message' %>
+      </p>
+    </div>
+    <div class="logo">
+      <%= image_tag "logo.png" %>
+    </div>
+  </div>
+</div>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -32,6 +32,9 @@ de:
       column_activity: "Letzte Aktivität"
     current_session: "Aktive Session"
     end_session: "Session beenden"
+  two_factor_not_configured:
+    title: "Zweiter Faktor nicht eingerichtet"
+    message: "Ein Zugriff von dieser IP-Adresse erfordert Zwei-Faktor-Authentifizierung. Melden Sie sich aus Ihrem internen Netzwerk an um die Zwei-Faktor-Authentifizierung für diesen Benutzer einzurichten."
   two_factor_authenticators:
     title: "Zwei-Faktor-Authentifizierung"
     setup: "Zwei-Faktor-Authentifizierung einrichten"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,9 @@ en:
       column_activity: "Most recent activity"
     current_session: "Current session"
     end_session: "End session"
+  two_factor_not_configured:
+    title: "Second factor not configured"
+    message: "Access from this IP requires two-factor authentication. Sign in from your internal network to configure two-factor authentication for this user."
   two_factor_authenticators:
     title: "Two-factor authentication"
     setup: "Set up two-factor authentication"
@@ -62,7 +65,7 @@ en:
         one: about one year
         other: about %{count} years
       almost_x_years:
-        one: nearly one year 
+        one: nearly one year
         other: nearly %{count} years
       half_a_minute: half minute
       less_than_x_minutes:

--- a/lib/casino.rb
+++ b/lib/casino.rb
@@ -44,6 +44,8 @@ module CASino
       lifetime_consumed: 86400
     },
     two_factor_authenticator: {
+      enforce: false,
+      whitelist: [],
       timeout: 180,
       lifetime_inactive: 300,
       drift: 30

--- a/spec/model/ip_whitelist_spec.rb
+++ b/spec/model/ip_whitelist_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+describe CASino::IPWhitelist do
+  describe 'empty' do
+    subject { CASino::IPWhitelist.new([]) }
+
+    it 'does not include anything' do
+      subject.should_not include("127.0.0.1")
+      subject.should_not include("192.168.0.3")
+      subject.should_not include("240.17.159.136")
+    end
+  end
+
+  describe 'fixed ip addresses' do
+    subject { CASino::IPWhitelist.new(["127.0.0.1", "192.168.0.1"]) }
+
+    it 'includes exact matches' do
+      subject.should include("127.0.0.1")
+      subject.should include("192.168.0.1")
+    end
+
+    it 'does not include any non-exact matches' do
+      subject.should_not include("192.168.0.3")
+      subject.should_not include("240.17.159.136")
+    end
+  end
+
+  describe 'subnets' do
+    subject { CASino::IPWhitelist.new(["192.168.3.0/24"]) }
+
+    it 'includes addresses within the subnet' do
+      subject.should include("192.168.3.98")
+      subject.should include("192.168.3.240")
+    end
+
+    it 'does not include addresses outside the subnet' do
+      subject.should_not include("240.17.159.136")
+      subject.should_not include("192.168.1.10")
+    end
+  end
+
+  describe 'ranges' do
+    subject { CASino::IPWhitelist.new([["192.168.1.10", "192.168.1.15"],
+                                       ["172.16.87.1", "172.16.87.140"]]) }
+
+    it 'includes addresses contained within the ranges' do
+      subject.should include("192.168.1.13")
+      subject.should include("172.16.87.56")
+    end
+
+    it 'does not include addresses outside the ranges' do
+      subject.should_not include("192.168.1.3")
+      subject.should_not include("172.17.10.1")
+      subject.should_not include("240.17.159.136")
+    end
+
+    it 'includes lower bound' do
+      subject.should include("192.168.1.10")
+      subject.should_not include("192.168.1.9")
+      subject.should include("172.16.87.1")
+    end
+
+    it 'includes upper bound' do
+      subject.should include("192.168.1.15")
+      subject.should_not include("192.168.1.16")
+      subject.should include("172.16.87.140")
+      subject.should_not include("172.16.87.141")
+    end
+  end
+end


### PR DESCRIPTION
Previously two-factor authentication was an opt-in per user. There are situations where two-factor auth is required to access a system.

This patch adds a configuration option:

```yaml
  two_factor_authenticator:
    whitelist:
      - 127.0.0.1
      - 192.168.1.0/24
      - ["172.16.10.5", "172.16.10.13"]
```

This option will enforce two-factor authentication for every login attempt coming from an ip outside the specified whitelist.

An informative text is displayed if the second factor has not been configured yet. The two-factor setup must happen from a whitelisted address.

**Note:**
This might be a niche use-case that only we are facing. I decided to prepare the PR nonetheless and let you decide wether this is something that you might be interested in getting back upstream.