### PR TITLE
make it possible to disable rememberMe.

### DIFF
--- a/app/controllers/casino/sessions_controller.rb
+++ b/app/controllers/casino/sessions_controller.rb
@@ -24,7 +24,8 @@ class CASino::SessionsController < CASino::ApplicationController
     if !validation_result
       show_login_error I18n.t('login_credential_acceptor.invalid_login_credentials')
     else
-      sign_in(validation_result, long_term: params[:rememberMe], credentials_supplied: true)
+      long_term = remember_me_enabled? && params[:rememberMe]
+      sign_in(validation_result, long_term: long_term, credentials_supplied: true)
     end
   end
 

--- a/app/helpers/casino/sessions_helper.rb
+++ b/app/helpers/casino/sessions_helper.rb
@@ -50,6 +50,10 @@ module CASino::SessionsHelper
     cookies.delete :tgt
   end
 
+  def remember_me_enabled?
+    CASino.config.ticket_granting_ticket[:lifetime_long_term] != -1
+  end
+
   private
   def handle_signed_in(tgt, options = {})
     if tgt.awaiting_two_factor_authentication?

--- a/app/views/casino/sessions/new.html.erb
+++ b/app/views/casino/sessions/new.html.erb
@@ -19,8 +19,10 @@
         <%= text_field_tag :username, params[:username], autofocus:true %>
         <%= label_tag :password, t('login.label_password') %>
         <%= password_field_tag :password %>
-        <%= label_tag :rememberMe do %>
-          <%= check_box_tag :rememberMe, 1, params[:rememberMe] %> <%= t('login.label_remember_me') %>
+        <% if remember_me_enabled? %>
+          <%= label_tag :rememberMe do %>
+            <%= check_box_tag :rememberMe, 1, params[:rememberMe] %> <%= t('login.label_remember_me') %>
+          <% end %>
         <% end %>
         <%= button_tag t('login.label_button'), :class => 'button' %>
       <% end %>
@@ -28,4 +30,3 @@
   </div>
   <%= render 'footer' %>
 </div>
-

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -228,6 +228,17 @@ describe CASino::SessionsController do
             tgt = CASino::TicketGrantingTicket.last
             tgt.long_term.should == true
           end
+
+          context 'with remember me disabled' do
+            before { CASino.config.ticket_granting_ticket[:lifetime_long_term] = -1 }
+            after { CASino.config.ticket_granting_ticket[:lifetime_long_term] = 864000 }
+
+            it 'does not create a long-term ticket-granting ticket' do
+              post :create, request_options
+              tgt = CASino::TicketGrantingTicket.last
+              tgt.long_term.should == false
+            end
+          end
         end
 
         context 'with two-factor authentication enabled' do

--- a/spec/features/login_spec.rb
+++ b/spec/features/login_spec.rb
@@ -65,4 +65,18 @@ describe 'Login' do
     it { should have_button('Login') }
     it { should have_text('Incorrect username or password') }
   end
+
+  context 'with remember me disabled' do
+    before { CASino.config.ticket_granting_ticket[:lifetime_long_term] = -1 }
+    after { CASino.config.ticket_granting_ticket[:lifetime_long_term] = 864000 }
+    before { visit login_path }
+
+    it { should_not have_field('rememberMe') }
+  end
+
+  context 'with remember me enabled' do
+    before { visit login_path }
+
+    it { should have_field('rememberMe') }
+  end
 end


### PR DESCRIPTION
The remember me functionality can be disabled completely by setting:

```yaml
ticket_granting_ticket:
  lifetime_long_term: -1
```

This does not only remove the "remember me" checkbox from the login screen but also makes the `SessionsController` ignore any posted `rememberMe` param.

I'm submitting this PR to see wether this is something that you feel should be configurable. I'd understand if that's not the case and we simply keep the patch for our fork.

Thanks for your time and a great project :yellow_heart: 