### PR TITLE
require 'yaml' in CASino::Engine

### DIFF
--- a/lib/casino/engine.rb
+++ b/lib/casino/engine.rb
@@ -1,5 +1,6 @@
 require 'casino'
 require 'casino/inflections'
+require 'yaml'
 
 module CASino
   class Engine < Rails::Engine


### PR DESCRIPTION
Hey there, I noticed this error trying to run `bundle exec rails g casino:install`

    /.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/casino-4.0.3/lib/casino/engine.rb:16:in `apply_yaml_config': uninitialized constant CASino::Engine::YAML (NameError)

this fixed the error for me locally. Please let me know if you have any questions or suggestions to improve this.

Cheers