### PR TITLE
Make the generated cookies httponly

### DIFF
--- a/app/helpers/casino/sessions_helper.rb
+++ b/app/helpers/casino/sessions_helper.rb
@@ -38,7 +38,7 @@ module CASino::SessionsHelper
   end
 
   def set_tgt_cookie(tgt)
-    cookies[:tgt] = { value: tgt.ticket }.tap do |cookie|
+    cookies[:tgt] = { value: tgt.ticket, httponly: true}.tap do |cookie|
       if tgt.long_term?
         cookie[:expires] = CASino.config.ticket_granting_ticket[:lifetime_long_term].seconds.from_now
       end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -369,6 +369,12 @@ describe CASino::SessionsController do
             ticket_granting_ticket.reload.should_not be_awaiting_two_factor_authentication
           end
 
+          it 'creates an httponly cookie' do
+            controller.stub(:cookies).and_return(HashWithIndifferentAccess.new)
+            post :validate_otp, request_options
+            controller.cookies['tgt']['httponly'].should be(true)
+          end
+
           context 'with a long-term ticket-granting ticket' do
             let(:cookie_jar) { HashWithIndifferentAccess.new }
 


### PR DESCRIPTION
The tgt cookie should be httponly to mitigate some common XSS attacks.
https://www.owasp.org/index.php/HttpOnly#Mitigating_the_Most_Common_XSS_attack_using_HttpOnly