### PR TITLE
fix: Broken README link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 CASino Rails Engine (used in CASinoApp).
 
-It currently supports [CAS 1.0 and CAS 2.0](http://jasig.github.io/cas) as well as [CAS 3.1 Single Sign Out](https://wiki.jasig.org/display/CASUM/Single+Sign+Out).
+It currently supports [CAS 1.0 and CAS 2.0](http://apereo.github.io/cas) as well as [CAS 3.1 Single Sign Out](https://wiki.jasig.org/display/CASUM/Single+Sign+Out).
 
 ## Setup
 


### PR DESCRIPTION
This fixes #160 - looks like the new landing page for CAS that moved from `http://jasig.github.io/cas` to `http://apereo.github.io/cas`.