### PR TITLE
Http Only TGT Cookies

### DIFF
--- a/app/helpers/casino/sessions_helper.rb
+++ b/app/helpers/casino/sessions_helper.rb
@@ -39,7 +39,7 @@ module CASino::SessionsHelper
   end
 
   def set_tgt_cookie(tgt)
-    cookies[:tgt] = { value: tgt.ticket, httponly: true}.tap do |cookie|
+    cookies[:tgt] = { value: tgt.ticket, httponly: !!CASino.config.httponly_tgt_cookies }.tap do |cookie|
       if tgt.long_term?
         cookie[:expires] = CASino.config.ticket_granting_ticket[:lifetime_long_term].seconds.from_now
       end

--- a/app/helpers/casino/sessions_helper.rb
+++ b/app/helpers/casino/sessions_helper.rb
@@ -39,7 +39,7 @@ module CASino::SessionsHelper
   end
 
   def set_tgt_cookie(tgt)
-    cookies[:tgt] = { value: tgt.ticket }.tap do |cookie|
+    cookies[:tgt] = { value: tgt.ticket, httponly: true}.tap do |cookie|
       if tgt.long_term?
         cookie[:expires] = CASino.config.ticket_granting_ticket[:lifetime_long_term].seconds.from_now
       end

--- a/lib/casino.rb
+++ b/lib/casino.rb
@@ -7,6 +7,7 @@ module CASino
   defaults = {
     authenticators: HashWithIndifferentAccess.new,
     require_service_rules: false,
+    httponly_tgt_cookies: false,
     logger: Rails.logger,
     frontend: HashWithIndifferentAccess.new(
       sso_name: 'CASino',

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -399,6 +399,12 @@ describe CASino::SessionsController do
             ticket_granting_ticket.reload.should_not be_awaiting_two_factor_authentication
           end
 
+          it 'creates an httponly cookie' do
+            controller.stub(:cookies).and_return(HashWithIndifferentAccess.new)
+            post :validate_otp, params
+            controller.cookies['tgt']['httponly'].should be(true)
+          end
+
           context 'with a long-term ticket-granting ticket' do
             let(:cookie_jar) { HashWithIndifferentAccess.new }
 


### PR DESCRIPTION
After a security audit our company went through, it was pointed out to us that our tgt cookies should be httponly. So, we added that feature.

In the code as-is right now, we are leaving the cookies as not httponly so as to not break backwards compatibility. However, my opinion is that it should probably default the cooking to being httponly, as this is the most secure option.