### PR TITLE
Fix failed specs and added rails-controller-testing gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
 - 2.0.0
 - 2.1.0
 - 2.2.2
+- 2.3.0
 notifications:
   hipchat:
     rooms:

--- a/casino.gemspec
+++ b/casino.gemspec
@@ -32,8 +32,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'factory_girl', '~> 4.1'
   s.add_development_dependency 'webmock', '~> 1.9'
   s.add_development_dependency 'coveralls', '~> 0.7'
+  s.add_development_dependency 'rails-controller-testing', '~> 0'
 
-  s.add_runtime_dependency 'rails', '>= 4.1.0', '< 4.3.0'
+  s.add_runtime_dependency 'rails', '>= 4.1.0', '< 5.0.0.1'
   s.add_runtime_dependency 'sass-rails', '>= 4.0.0', '< 6.0.0'
   s.add_runtime_dependency 'addressable', '~> 2.3'
   s.add_runtime_dependency 'terminal-table', '~> 1.4'

--- a/lib/casino/version.rb
+++ b/lib/casino/version.rb
@@ -1,3 +1,3 @@
 module CASino
-  VERSION = '4.1.2'
+  VERSION = '4.1.3'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 ENV["RAILS_ENV"] ||= 'test'
 
 require 'coveralls'
+require 'rails-controller-testing'
 Coveralls.wear!
 
 SimpleCov.formatter = Coveralls::SimpleCov::Formatter


### PR DESCRIPTION
https://github.com/rbCAS/CASino/issues/168

@pencil @luxflux : Please review this code. Most of the spec fix by adding [this gem](https://github.com/rails/rails-controller-testing). and still to many DEPRECATION WARNING exist and some specs still failing. Any idea why this specs failing ?

```
1) CASino::ProxyTicketsController GET "proxy" with a proxy-granting ticket without a targetService answers with the failure text
2) CASino::ProxyTicketsController GET "proxy" with a proxy-granting ticket without a targetService does not create a proxy ticket
3) CASino::SessionsController GET "destroy_others" with an existing ticket-granting ticket redirects to the session overview
4) CASino::SessionsController GET "new" with an unsupported format sets the status code to 406
```

Thanks