### PR TITLE
Feature/use in mounted rails engine

### DIFF
--- a/lib/generators/casino/install/install_generator.rb
+++ b/lib/generators/casino/install/install_generator.rb
@@ -27,11 +27,11 @@ module CASino
       return unless options['config_files']
 
       copy_file 'cas.yml', 'config/cas.yml'
-      copy_file 'casino_and_overrides.scss', 'app/assets/stylesheets/casino_and_overrides.scss'
+      copy_file 'casino_and_overrides.scss', build_file_path('app/assets/stylesheets', '/casino_and_overrides.scss')
     end
 
     def insert_assets_loader
-      insert_into_file 'app/assets/javascripts/application.js', :after => %r{//= require +['"]?jquery_ujs['"]?} do
+      insert_into_file build_file_path('app/assets/javascripts', '/application.js'), :after => %r{//= require +['"]?jquery_ujs['"]?} do
         "\n//= require casino"
       end
     end
@@ -43,5 +43,14 @@ module CASino
     def show_readme
       readme 'README'
     end
+
+    private
+      def build_file_path(root, path)
+        engine_name = Rails::Generators.namespace.to_s.underscore
+        engine_path = "/#{engine_name}" unless engine_name.blank?
+
+        [root, engine_path, path].compact.join
+      end
+
   end
 end

--- a/lib/generators/casino/install/install_generator.rb
+++ b/lib/generators/casino/install/install_generator.rb
@@ -27,11 +27,11 @@ module CASino
       return unless options['config_files']
 
       copy_file 'cas.yml', 'config/cas.yml'
-      copy_file 'casino_and_overrides.scss', build_file_path('app/assets/stylesheets', '/casino_and_overrides.scss')
+      copy_file 'casino_and_overrides.scss', "app/assets/stylesheets/#{namespace_name}/casino_and_overrides.scss".squeeze('/')
     end
 
     def insert_assets_loader
-      insert_into_file build_file_path('app/assets/javascripts', '/application.js'), :after => %r{//= require +['"]?jquery_ujs['"]?} do
+      insert_into_file "app/assets/javascripts/#{namespace_name}/application.js".squeeze('/'), :after => %r{//= require +['"]?jquery_ujs['"]?} do
         "\n//= require casino"
       end
     end
@@ -45,11 +45,8 @@ module CASino
     end
 
     private
-      def build_file_path(root, path)
-        engine_name = Rails::Generators.namespace.to_s.underscore
-        engine_path = "/#{engine_name}" unless engine_name.blank?
-
-        [root, engine_path, path].compact.join
+      def namespace_name
+        Rails::Generators.namespace.to_s.underscore
       end
 
   end

--- a/lib/generators/casino/install/install_generator.rb
+++ b/lib/generators/casino/install/install_generator.rb
@@ -20,7 +20,7 @@ module CASino
     def install_migrations
       return unless options['migration']
 
-      rake 'casino:install:migrations'
+      generate 'casino:migration'
     end
 
     def copy_config_files

--- a/lib/generators/casino/migration_generator.rb
+++ b/lib/generators/casino/migration_generator.rb
@@ -12,7 +12,6 @@ module CASino
     def install
       source_paths.each do |source_path|
         Dir["#{source_path}/*.rb"].each do |filename|
-          puts "MIGRATION TEMPLATE: #{File.basename(filename)}"
           migration_template File.basename(filename), "db/migrate/#{File.basename(filename).sub(/^\d+_/, '')}"
         end
       end

--- a/lib/generators/casino/migration_generator.rb
+++ b/lib/generators/casino/migration_generator.rb
@@ -1,0 +1,25 @@
+require 'rails/generators/active_record'
+
+module CASino
+  class MigrationGenerator < ::Rails::Generators::Base
+    include Rails::Generators::Migration
+    source_root File.expand_path('../../../../db/migrate', __FILE__)
+
+    namespace 'casino:migration'
+
+    desc 'Installs CASino migration files.'
+    
+    def install
+      source_paths.each do |source_path|
+        Dir["#{source_path}/*.rb"].each do |filename|
+          puts "MIGRATION TEMPLATE: #{File.basename(filename)}"
+          migration_template File.basename(filename), "db/migrate/#{File.basename(filename).sub(/^\d+_/, '')}"
+        end
+      end
+    end
+
+    def self.next_migration_number(dirname)
+      ActiveRecord::Generators::Base.next_migration_number(dirname)
+    end
+  end
+end


### PR DESCRIPTION
Accidentally closed https://github.com/rbCAS/CASino/pull/130 - moved feature to a branch to track separately.

Added Rails engine "namespace" to asset paths when installing CASino. Added migrations generator to copy migrations because the built-in `rake railties:install:migrations` does not work when running the command on a Rails engine. It's a simple fix to copy the files.

Given, we may have a special case where we're mounting CASino in another mountable Rails engine.

You can test this by creating a mountable Rails engine, and mounting CASino. Then (from the rails engine root) try running the generator `rails g casino:install` or the Rake command `rake casino:install:migrations`. It doesn't seem to work (with the old code), but works now with this new generator.