### PR TITLE
Add dependencies removal for the user entity

### DIFF
--- a/app/models/casino/user.rb
+++ b/app/models/casino/user.rb
@@ -2,9 +2,9 @@
 class CASino::User < ActiveRecord::Base
   serialize :extra_attributes, Hash
 
-  has_many :ticket_granting_tickets
-  has_many :two_factor_authenticators
-  has_many :login_attempts
+  has_many :ticket_granting_tickets, dependent: :destroy
+  has_many :two_factor_authenticators, dependent: :destroy
+  has_many :login_attempts, dependent: :destroy
 
   def active_two_factor_authenticator
     self.two_factor_authenticators.where(active: true).first

--- a/spec/model/user_spec.rb
+++ b/spec/model/user_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'useragent'
 
 describe CASino::User do
   let(:user) {  FactoryGirl.create :user }

--- a/spec/model/user_spec.rb
+++ b/spec/model/user_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+require 'useragent'
+
+describe CASino::User do
+  let(:user) {  FactoryGirl.create :user }
+
+  let!(:ticket_granting_ticket) { FactoryGirl.create :ticket_granting_ticket, user: user }
+  let!(:two_factor_authenticator) { FactoryGirl.create :two_factor_authenticator, user: user }
+  let!(:login_attempt) { FactoryGirl.create :login_attempt, user: user }
+
+  subject { user }
+
+  describe '#destroy' do
+    before(:each) do
+      CASino::ServiceTicket::SingleSignOutNotifier.any_instance.stub(:notify).and_return(false)
+    end
+
+    it 'deletes depending ticket-granting-ticket' do
+      lambda {
+        user.destroy
+      }.should change(CASino::TicketGrantingTicket, :count).by(-1)
+    end
+
+    it 'deletes depending two-factor-authenticator' do
+      lambda {
+        user.destroy
+      }.should change(CASino::TwoFactorAuthenticator, :count).by(-1)
+    end
+
+    it 'deletes depending login-attempt' do
+      lambda {
+        user.destroy
+      }.should change(CASino::LoginAttempt, :count).by(-1)
+    end
+  end
+end


### PR DESCRIPTION
When user is removed lots of "trash" stays in the DB. 
IMHO it would be best just to add `dependent: :destroy` for user's `has_many` associations.